### PR TITLE
#9 Fix TrimmedDataAccessException when trying to listen to the table stream

### DIFF
--- a/src/main/java/co/novandi/diaz/client/DbStreamListener.java
+++ b/src/main/java/co/novandi/diaz/client/DbStreamListener.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsAsyncClient;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -44,7 +45,9 @@ public class DbStreamListener {
                         .build())
                 .whenComplete((describeStreamResponse, describeStreamsError) ->
                         Optional.ofNullable(describeStreamResponse).ifPresentOrElse(
-                                response -> response.streamDescription().shards().forEach(shard -> this.observeShard(shard, tableStreamArn)),
+                                response -> response.streamDescription().shards().stream()
+                                        .filter(shard -> Objects.isNull(shard.sequenceNumberRange().endingSequenceNumber()))
+                                        .forEach(shard -> this.observeShard(shard, tableStreamArn)),
                                 () -> log.error("Unable to observe the table stream {}. Reason: {}", tableStreamArn, describeStreamsError.getMessage())))
                 .join();
     }


### PR DESCRIPTION
Changing the `listenToRecordChanges` logic to only iterate the current shard, which does not have `EndingSequenceNumber`